### PR TITLE
Add negligible delay to byte clock advancement

### DIFF
--- a/blinkt.c
+++ b/blinkt.c
@@ -325,6 +325,7 @@ void send_byte(uint8_t x)
         }
 
         digitalWrite(CLK, 1);
+        delay(0.0001);
         digitalWrite(CLK, 0);
         x = x << 1;
     }

--- a/blinkt.c
+++ b/blinkt.c
@@ -325,7 +325,7 @@ void send_byte(uint8_t x)
         }
 
         digitalWrite(CLK, 1);
-        delay(0.0001);
+        delay(0);
         digitalWrite(CLK, 0);
         x = x << 1;
     }


### PR DESCRIPTION
Allow leeway for clock advancement to prevent activity on the CPU interrupting the clock and causing a bitshift